### PR TITLE
[Feature] 주문 내역 생성 API 구현

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,8 @@
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
-        "typeorm": "^0.3.7"
+        "typeorm": "^0.3.7",
+        "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -8291,6 +8292,14 @@
         }
       }
     },
+    "node_modules/typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "peerDependencies": {
+        "typeorm": "^0.2.0 || ^0.3.0"
+      }
+    },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -14959,6 +14968,12 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
+    },
+    "typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "requires": {}
     },
     "typescript": {
       "version": "4.7.4",

--- a/server/package.json
+++ b/server/package.json
@@ -31,7 +31,8 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
-    "typeorm": "^0.3.7"
+    "typeorm": "^0.3.7",
+    "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/server/src/choice/choice.controller.ts
+++ b/server/src/choice/choice.controller.ts
@@ -9,7 +9,7 @@ export class ChoiceController {
   @Get()
   async getMenuOptionsByMenuId(
     @Res() res: Response,
-    @Query('menu_id') menuId: string,
+    @Query('menu-id') menuId: string,
   ) {
     const options = await this.choiceService.getChoicesByMenuId(
       parseInt(menuId),

--- a/server/src/choice/choice.module.ts
+++ b/server/src/choice/choice.module.ts
@@ -9,5 +9,6 @@ import { ChoiceService } from './choice.service';
   imports: [TypeOrmModule.forFeature([Choice, ChoiceGroup])],
   controllers: [ChoiceController],
   providers: [ChoiceService],
+  exports: [ChoiceService],
 })
 export class ChoiceModule {}

--- a/server/src/choice/choice.service.ts
+++ b/server/src/choice/choice.service.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Choice } from './entities/choice.entity';
 import { ChoiceGroup } from './entities/choiceGroup.entity';
 
 @Injectable()
 export class ChoiceService {
   constructor(
+    @InjectRepository(Choice)
+    private choiceRepository: Repository<Choice>,
     @InjectRepository(ChoiceGroup)
     private choiceGroupRepository: Repository<ChoiceGroup>,
   ) {}
@@ -15,5 +18,14 @@ export class ChoiceService {
       where: { choices: { menus: { menuToChoice: { id: menuId } } } },
       relations: ['choices'],
     });
+  }
+
+  async getChoiceById(choiceId: number) {
+    return await this.choiceRepository.findOneBy({ id: choiceId });
+  }
+
+  async getExtraChargeById(choiceId: number) {
+    const choice = await this.getChoiceById(choiceId);
+    return choice.extraCharge;
   }
 }

--- a/server/src/menu/menu.module.ts
+++ b/server/src/menu/menu.module.ts
@@ -9,5 +9,6 @@ import { MenuService } from './menu.service';
   imports: [TypeOrmModule.forFeature([Menu, MenuCategory])],
   controllers: [MenuController],
   providers: [MenuService],
+  exports: [MenuService],
 })
 export class MenuModule {}

--- a/server/src/menu/menu.service.ts
+++ b/server/src/menu/menu.service.ts
@@ -1,29 +1,30 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Menu } from './entities/menu.entity';
 import { MenuCategory } from './entities/menuCategory.entity';
 
 @Injectable()
 export class MenuService {
   constructor(
+    @InjectRepository(Menu)
+    private menuRepository: Repository<Menu>,
     @InjectRepository(MenuCategory)
     private menuCategoryRepository: Repository<MenuCategory>,
   ) {}
 
   async getAllMenusByCategory(): Promise<MenuCategory[]> {
     return await this.menuCategoryRepository.find({
-      relations: {
-        menus: true,
-      },
-      order: {
-        menus: {
-          id: 'ASC',
-        },
-      },
+      relations: { menus: true },
+      order: { menus: { id: 'ASC' } },
     });
   }
 
   async getAllCategories(): Promise<MenuCategory[]> {
     return await this.menuCategoryRepository.find();
+  }
+
+  async getById(id: number): Promise<Menu> {
+    return await this.menuRepository.findOneBy({ id });
   }
 }

--- a/server/src/order/dto/createOrderDto.ts
+++ b/server/src/order/dto/createOrderDto.ts
@@ -6,7 +6,9 @@ export class CreateOrderDto {
   soldMenus: CreateOrderSoldMenuDto[];
 }
 
-class CreateOrderSoldMenuDto extends PickType(SoldMenu, ['quantity'] as const) {
+export class CreateOrderSoldMenuDto extends PickType(SoldMenu, [
+  'quantity',
+] as const) {
   menuId: number;
   choiceIds: number[];
 }

--- a/server/src/order/dto/createOrderDto.ts
+++ b/server/src/order/dto/createOrderDto.ts
@@ -1,0 +1,12 @@
+import { SoldMenu } from 'src/order/entities/soldMenu.entity';
+import { PickType } from '@nestjs/mapped-types';
+
+export class CreateOrderDto {
+  paymentMethodId: number;
+  soldMenus: CreateOrderSoldMenuDto[];
+}
+
+class CreateOrderSoldMenuDto extends PickType(SoldMenu, ['quantity'] as const) {
+  menuId: number;
+  choiceIds: number[];
+}

--- a/server/src/order/dto/createSoldMenuDto.ts
+++ b/server/src/order/dto/createSoldMenuDto.ts
@@ -1,0 +1,10 @@
+import { PickType } from '@nestjs/mapped-types';
+import { SoldMenu } from 'src/order/entities/soldMenu.entity';
+
+export class CreateSoldMenuDto extends PickType(SoldMenu, [
+  'menu',
+  'choiceSummary',
+  'quantity',
+  'sales',
+  'order',
+] as const) {}

--- a/server/src/order/entities/soldMenu.entity.ts
+++ b/server/src/order/entities/soldMenu.entity.ts
@@ -13,6 +13,9 @@ export class SoldMenu {
   @Column('decimal')
   sales: number;
 
+  @Column()
+  choiceSummary: string;
+
   @ManyToOne(() => Order, (order) => order.soldMenus)
   order: Order;
 

--- a/server/src/order/order.controller.ts
+++ b/server/src/order/order.controller.ts
@@ -1,7 +1,13 @@
-import { Controller } from '@nestjs/common';
+import { CreateOrderDto } from './dto/createOrderDto';
+import { Body, Controller, Post } from '@nestjs/common';
 import { OrderService } from './order.service';
 
 @Controller('order')
 export class OrderController {
   constructor(private readonly orderService: OrderService) {}
+
+  @Post()
+  create(@Body() createOrderDto: CreateOrderDto) {
+    return this.orderService.create(createOrderDto);
+  }
 }

--- a/server/src/order/order.module.ts
+++ b/server/src/order/order.module.ts
@@ -1,8 +1,20 @@
+import { ChoiceModule } from './../choice/choice.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
 import { OrderService } from './order.service';
 import { OrderController } from './order.controller';
+import { Order } from './entities/order.entity';
+import { SoldMenu } from './entities/soldMenu.entity';
+import { PaymentMethodModule } from 'src/paymentMethod/paymentMethod.module';
+import { MenuModule } from 'src/menu/menu.module';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Order, SoldMenu]),
+    PaymentMethodModule,
+    MenuModule,
+    ChoiceModule,
+  ],
   controllers: [OrderController],
   providers: [OrderService],
 })

--- a/server/src/order/order.service.ts
+++ b/server/src/order/order.service.ts
@@ -1,4 +1,91 @@
+import { Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { ChoiceService } from 'src/choice/choice.service';
+import { MenuService } from 'src/menu/menu.service';
+import { PaymentMethodService } from 'src/paymentMethod/paymentMethod.service';
+
+import { CreateOrderDto, CreateOrderSoldMenuDto } from './dto/createOrderDto';
+import { CreateSoldMenuDto } from './dto/createSoldMenuDto';
+
+import { Order } from './entities/order.entity';
+import { Menu } from 'src/menu/entities/menu.entity';
+import { SoldMenu } from 'src/order/entities/soldMenu.entity';
+import { Choice } from 'src/choice/entities/choice.entity';
 
 @Injectable()
-export class OrderService {}
+export class OrderService {
+  constructor(
+    @InjectRepository(Order)
+    private orderRepository: Repository<Order>,
+    @InjectRepository(SoldMenu)
+    private soldMenuRepository: Repository<SoldMenu>,
+
+    private menuService: MenuService,
+    private paymentMethodService: PaymentMethodService,
+    private choiceService: ChoiceService,
+  ) {}
+
+  async create(createOrderDto: CreateOrderDto) {
+    const { paymentMethodId, soldMenus } = createOrderDto;
+    const newOrder = await this.createOrder(paymentMethodId);
+
+    soldMenus.forEach(async (soldMenu) => {
+      const createSoldMenuDto = await this.makeCreateSoldMenuDto(
+        soldMenu,
+        newOrder,
+      );
+      this.createSoldMenu(createSoldMenuDto);
+    });
+  }
+
+  async createOrder(paymentMethodId: number) {
+    const paymentMethod = await this.paymentMethodService.findById(
+      paymentMethodId,
+    );
+    const newOrder = this.orderRepository.create({ paymentMethod });
+    return await this.orderRepository.save(newOrder);
+  }
+
+  async createSoldMenu(createSoldMenuDto: CreateSoldMenuDto) {
+    const newSoldMenu = this.soldMenuRepository.create(createSoldMenuDto);
+    await this.soldMenuRepository.save(newSoldMenu);
+  }
+
+  calculateSales(menu: Menu, choices: Choice[]) {
+    const basePrice = menu.basePrice;
+    const totalExtraCharge = choices.reduce(
+      (totalExtraCharge, choice) => totalExtraCharge + choice.extraCharge,
+      0,
+    );
+    return basePrice + totalExtraCharge;
+  }
+
+  makeChoiceSummary(choices: Choice[]) {
+    const choiceSummary = choices.map((choice) => choice.name);
+    return JSON.stringify(choiceSummary);
+  }
+
+  async makeCreateSoldMenuDto(
+    soldMenu: CreateOrderSoldMenuDto,
+    order: Order,
+  ): Promise<CreateSoldMenuDto> {
+    const { menuId, quantity, choiceIds } = soldMenu;
+    const menu = await this.menuService.getById(menuId);
+    const choices = await Promise.all(
+      choiceIds.map((choiceId) => this.choiceService.getChoiceById(choiceId)),
+    );
+
+    const sales = this.calculateSales(menu, choices);
+    const choiceSummary = this.makeChoiceSummary(choices);
+
+    return {
+      menu,
+      choiceSummary,
+      quantity,
+      sales,
+      order,
+    };
+  }
+}

--- a/server/src/paymentMethod/paymentMethod.module.ts
+++ b/server/src/paymentMethod/paymentMethod.module.ts
@@ -8,5 +8,6 @@ import { PaymentMethod } from './entities/paymentMethod.entity';
   imports: [TypeOrmModule.forFeature([PaymentMethod])],
   controllers: [PaymentMethodController],
   providers: [PaymentMethodService],
+  exports: [PaymentMethodService],
 })
 export class PaymentMethodModule {}

--- a/server/src/paymentMethod/paymentMethod.service.ts
+++ b/server/src/paymentMethod/paymentMethod.service.ts
@@ -13,4 +13,8 @@ export class PaymentMethodService {
   async findAll() {
     return await this.paymentMethodRepository.find();
   }
+
+  async findById(id: number) {
+    return await this.paymentMethodRepository.findOneBy({ id });
+  }
 }

--- a/server/src/typeorm.config.ts
+++ b/server/src/typeorm.config.ts
@@ -1,5 +1,6 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { config } from 'dotenv';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 config();
 
@@ -12,4 +13,8 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   database: process.env.DB_NAME,
   entities: [__dirname + '/**/entities/*.entity.{js,ts}'],
   synchronize: process.env.NODE_ENV === 'development',
+  namingStrategy: new SnakeNamingStrategy(),
+  extra: {
+    decimalNumbers: true,
+  },
 };


### PR DESCRIPTION
## 설명

- 주문 내역을 생성하기 위한 POST API 구현

## 작업한 내용

- Order service 로직을 구현했습니다.
- 필요한 경우 다른 모듈의 Service 로직을 가져다 사용합니다.

## 특이사항
- 상품 판매내역을 저장하는 table에서는 Choice들을 외래키로 가지고 있지 않게 바꿨습니다.
- 값 검증이나 에러처리는 아직 전혀 하지 않았습니다.
- 프론트 기본 구현이 어느정도 되면 곧 이어 진행할 예정입니다.

## 관련이슈

- #8 
