### PR TITLE
feat: 카테고리별 매출 순위를 조회하는 API 구현

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { typeORMConfig } from './typeorm.config';
 import { MenuModule } from './menu/menu.module';
 import { ChoiceModule } from './choice/choice.module';

--- a/server/src/choice/choice.controller.ts
+++ b/server/src/choice/choice.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query, Res, HttpStatus } from '@nestjs/common';
-import { ChoiceService } from './choice.service';
 import { Response } from 'express';
+
+import { ChoiceService } from './choice.service';
 
 @Controller('choices')
 export class ChoiceController {

--- a/server/src/choice/choice.module.ts
+++ b/server/src/choice/choice.module.ts
@@ -1,5 +1,6 @@
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { Choice } from './entities/choice.entity';
 import { ChoiceGroup } from './entities/choiceGroup.entity';
 import { ChoiceController } from './choice.controller';

--- a/server/src/choice/choice.service.ts
+++ b/server/src/choice/choice.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+
 import { Choice } from './entities/choice.entity';
 import { ChoiceGroup } from './entities/choiceGroup.entity';
 

--- a/server/src/choice/entities/choice.entity.ts
+++ b/server/src/choice/entities/choice.entity.ts
@@ -5,6 +5,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 import { ChoiceGroup } from './choiceGroup.entity';
 import { MenuHasChoice } from 'src/menu/entities/menuHasChoice.entity';
 

--- a/server/src/choice/entities/choiceGroup.entity.ts
+++ b/server/src/choice/entities/choiceGroup.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
 import { Choice } from './choice.entity';
 
 @Entity()

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+
 import { AppModule } from './app.module';
 
 async function bootstrap() {

--- a/server/src/menu/entities/menu.entity.ts
+++ b/server/src/menu/entities/menu.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   OneToMany,
 } from 'typeorm';
+
 import { MenuCategory } from './menuCategory.entity';
 import { MenuHasChoice } from './menuHasChoice.entity';
 import { SoldMenu } from 'src/order/entities/soldMenu.entity';

--- a/server/src/menu/entities/menuCategory.entity.ts
+++ b/server/src/menu/entities/menuCategory.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
 import { Menu } from './menu.entity';
 
 @Entity({

--- a/server/src/menu/entities/menuHasChoice.entity.ts
+++ b/server/src/menu/entities/menuHasChoice.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
 import { Menu } from './menu.entity';
 import { Choice } from 'src/choice/entities/choice.entity';
 

--- a/server/src/menu/menu.controller.ts
+++ b/server/src/menu/menu.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, HttpStatus, Param, Query, Res } from '@nestjs/common';
-import { MenuService } from './menu.service';
 import { Response } from 'express';
+import { Controller, Get, HttpStatus, Query, Res } from '@nestjs/common';
+
+import { MenuService } from './menu.service';
 
 @Controller('menus')
 export class MenuController {

--- a/server/src/menu/menu.controller.ts
+++ b/server/src/menu/menu.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Param, Query, Res } from '@nestjs/common';
 import { MenuService } from './menu.service';
 import { Response } from 'express';
 
@@ -16,5 +16,16 @@ export class MenuController {
   async getAllCategories(@Res() res: Response) {
     const categories = await this.menuService.getAllCategories();
     return res.status(HttpStatus.OK).json({ categories });
+  }
+
+  @Get('ranking')
+  async getSalesRanking(
+    @Res() res: Response,
+    @Query('category-id') categoryId: string,
+  ) {
+    const salesRanking = await this.menuService.getSalesRanking(
+      parseInt(categoryId),
+    );
+    return res.status(HttpStatus.OK).json({ salesRanking });
   }
 }

--- a/server/src/menu/menu.module.ts
+++ b/server/src/menu/menu.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { Menu } from './entities/menu.entity';
 import { MenuCategory } from './entities/menuCategory.entity';
-import { MenuController } from './menu.controller';
 import { MenuService } from './menu.service';
+import { MenuController } from './menu.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Menu, MenuCategory])],

--- a/server/src/menu/menu.service.ts
+++ b/server/src/menu/menu.service.ts
@@ -1,9 +1,10 @@
-import { SoldMenu } from 'src/order/entities/soldMenu.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+
 import { Menu } from './entities/menu.entity';
 import { MenuCategory } from './entities/menuCategory.entity';
+import { SoldMenu } from 'src/order/entities/soldMenu.entity';
 
 @Injectable()
 export class MenuService {

--- a/server/src/menu/menu.service.ts
+++ b/server/src/menu/menu.service.ts
@@ -1,3 +1,4 @@
+import { SoldMenu } from 'src/order/entities/soldMenu.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -26,5 +27,41 @@ export class MenuService {
 
   async getById(id: number): Promise<Menu> {
     return await this.menuRepository.findOneBy({ id });
+  }
+
+  async getMenusWithSalesLog(categoryId: number) {
+    return await this.menuRepository.find({
+      relations: ['soldMenus'],
+      select: ['id', 'name', 'soldMenus'],
+      where: { category: { id: categoryId } },
+    });
+  }
+
+  calculateTotalSoldQuantities(soldMenus: SoldMenu[]) {
+    return soldMenus.reduce(
+      (totalQuantity, soldMenu) => totalQuantity + soldMenu.quantity,
+      0,
+    );
+  }
+
+  getMenusWithTotalSalesLog(menusWithSalesLog: Menu[]) {
+    return menusWithSalesLog.map((menuWithSalesLog) => {
+      const { id, name, soldMenus } = menuWithSalesLog;
+      const totalSoldQuantity = this.calculateTotalSoldQuantities(soldMenus);
+      return {
+        id,
+        name,
+        totalSoldQuantity,
+      };
+    });
+  }
+
+  async getSalesRanking(categoryId: number) {
+    const menusWithSalesLog = await this.getMenusWithSalesLog(categoryId);
+    const menusWithTotalSalesLog =
+      this.getMenusWithTotalSalesLog(menusWithSalesLog);
+    return menusWithTotalSalesLog.sort(
+      (a, b) => b.totalSoldQuantity - a.totalSoldQuantity,
+    );
   }
 }

--- a/server/src/order/dto/createOrderDto.ts
+++ b/server/src/order/dto/createOrderDto.ts
@@ -1,5 +1,6 @@
-import { SoldMenu } from 'src/order/entities/soldMenu.entity';
 import { PickType } from '@nestjs/mapped-types';
+
+import { SoldMenu } from 'src/order/entities/soldMenu.entity';
 
 export class CreateOrderDto {
   paymentMethodId: number;

--- a/server/src/order/dto/createSoldMenuDto.ts
+++ b/server/src/order/dto/createSoldMenuDto.ts
@@ -1,4 +1,5 @@
 import { PickType } from '@nestjs/mapped-types';
+
 import { SoldMenu } from 'src/order/entities/soldMenu.entity';
 
 export class CreateSoldMenuDto extends PickType(SoldMenu, [

--- a/server/src/order/entities/order.entity.ts
+++ b/server/src/order/entities/order.entity.ts
@@ -1,4 +1,3 @@
-import { PaymentMethod } from 'src/paymentMethod/entities/paymentMethod.entity';
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -6,7 +5,9 @@ import {
   OneToMany,
   CreateDateColumn,
 } from 'typeorm';
+
 import { SoldMenu } from './soldMenu.entity';
+import { PaymentMethod } from 'src/paymentMethod/entities/paymentMethod.entity';
 
 @Entity()
 export class Order {

--- a/server/src/order/entities/soldMenu.entity.ts
+++ b/server/src/order/entities/soldMenu.entity.ts
@@ -1,6 +1,7 @@
-import { Menu } from 'src/menu/entities/menu.entity';
 import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+
 import { Order } from './order.entity';
+import { Menu } from 'src/menu/entities/menu.entity';
 
 @Entity()
 export class SoldMenu {

--- a/server/src/order/order.controller.ts
+++ b/server/src/order/order.controller.ts
@@ -1,5 +1,6 @@
-import { CreateOrderDto } from './dto/createOrderDto';
 import { Body, Controller, Post } from '@nestjs/common';
+
+import { CreateOrderDto } from './dto/createOrderDto';
 import { OrderService } from './order.service';
 
 @Controller('order')

--- a/server/src/order/order.module.ts
+++ b/server/src/order/order.module.ts
@@ -1,10 +1,11 @@
-import { ChoiceModule } from './../choice/choice.module';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { OrderService } from './order.service';
 import { OrderController } from './order.controller';
 import { Order } from './entities/order.entity';
 import { SoldMenu } from './entities/soldMenu.entity';
+import { ChoiceModule } from '../choice/choice.module';
 import { PaymentMethodModule } from 'src/paymentMethod/paymentMethod.module';
 import { MenuModule } from 'src/menu/menu.module';
 

--- a/server/src/paymentMethod/entities/paymentMethod.entity.ts
+++ b/server/src/paymentMethod/entities/paymentMethod.entity.ts
@@ -1,5 +1,6 @@
-import { Order } from 'src/order/entities/order.entity';
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+
+import { Order } from 'src/order/entities/order.entity';
 
 @Entity()
 export class PaymentMethod {

--- a/server/src/paymentMethod/paymentMethod.controller.ts
+++ b/server/src/paymentMethod/paymentMethod.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Res, HttpStatus } from '@nestjs/common';
-import { PaymentMethodService } from './paymentMethod.service';
 import { Response } from 'express';
+import { Controller, Get, Res, HttpStatus } from '@nestjs/common';
+
+import { PaymentMethodService } from './paymentMethod.service';
 
 @Controller('payment-methods')
 export class PaymentMethodController {

--- a/server/src/paymentMethod/paymentMethod.module.ts
+++ b/server/src/paymentMethod/paymentMethod.module.ts
@@ -1,8 +1,9 @@
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { PaymentMethod } from './entities/paymentMethod.entity';
 import { PaymentMethodService } from './paymentMethod.service';
 import { PaymentMethodController } from './paymentMethod.controller';
-import { PaymentMethod } from './entities/paymentMethod.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PaymentMethod])],

--- a/server/src/paymentMethod/paymentMethod.service.ts
+++ b/server/src/paymentMethod/paymentMethod.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+
 import { PaymentMethod } from './entities/paymentMethod.entity';
 
 @Injectable()

--- a/server/src/typeorm.config.ts
+++ b/server/src/typeorm.config.ts
@@ -1,6 +1,6 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
-import { config } from 'dotenv';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { config } from 'dotenv';
 
 config();
 


### PR DESCRIPTION
## 설명

- 각 카테고리별로 많이 팔린 품목을 알기 위한 API 입니다. 

## 작업한 내용

<img width="459" alt="스크린샷 2022-08-08 오전 1 01 32" src="https://user-images.githubusercontent.com/95538993/183300090-ced23dd9-2196-48ca-be11-88e0f4f814c8.png">

- 매출 순위를 배열 형태로 응답합니다
- 매출이 없으면 배열에 들어있지 않습니다

## 특이사항
- import 순서를 정렬하느라 변경 파일이 좀 많습니다.
- menu.service.ts와 menu.controller.ts 파일 두 개만 보시면 될 듯합니다.

## 관련이슈

- #12
