### PR TITLE
메인화면 카트 마무리

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -35,7 +35,8 @@
     ],
     "no-use-before-define": "off",
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/require-default-props": [0]
   },
   "settings": {
     "import/resolver": {

--- a/client/src/components/Cart/CartInfo/index.tsx
+++ b/client/src/components/Cart/CartInfo/index.tsx
@@ -1,17 +1,33 @@
 import styled from 'styled-components';
 import { colors } from 'style/constants';
 import mixin from 'style/mixin';
+import { useCartStateContext } from 'store/cart/cartContext';
+import { formatMoneyString } from 'utils';
 
 export default function CartInfo() {
+  const cartState = useCartStateContext();
+
+  const calTotalAmounts = (): { totalQuantity: number; totalPrice: number } =>
+    cartState.reduce(
+      (amounts, cartItem) => {
+        const newAmounts = { ...amounts };
+        newAmounts.totalQuantity += cartItem.quantity;
+        newAmounts.totalPrice += cartItem.totalPricePerEach * cartItem.quantity;
+        return newAmounts;
+      },
+      { totalQuantity: 0, totalPrice: 0 }
+    );
+
+  const { totalQuantity, totalPrice } = calTotalAmounts();
   return (
     <CartInfoWrapper>
       <CartInfoItem>
         <InfoTitle>총 수량 : </InfoTitle>
-        <InfoContent>0 개</InfoContent>
+        <InfoContent>{totalQuantity} 개</InfoContent>
       </CartInfoItem>
       <CartInfoItem>
         <InfoTitle>총 금액 : </InfoTitle>
-        <InfoContent>0 원</InfoContent>
+        <InfoContent>{formatMoneyString(totalPrice)}</InfoContent>
       </CartInfoItem>
     </CartInfoWrapper>
   );

--- a/client/src/components/Cart/CartMenuList/CartMenuItem/index.tsx
+++ b/client/src/components/Cart/CartMenuList/CartMenuItem/index.tsx
@@ -8,7 +8,7 @@ import { formatMoneyString } from 'utils';
 import QuantityController from 'components/QuantityController';
 import { useCartDispatchContext } from 'store/cart/cartContext';
 import Container from 'components/common/Container';
-import { MIN_ORDER_QUANTITY, MAX_ORDER_QUANTITY } from 'constants';
+import { policy } from 'policy';
 
 export default function CartMenuItem({ cartItem }: { cartItem: ICartItem }) {
   const { id, name, imgUrl, totalPricePerEach, quantity } = cartItem;
@@ -40,8 +40,8 @@ export default function CartMenuItem({ cartItem }: { cartItem: ICartItem }) {
           <QuantityController
             quantity={quantity}
             setQuantity={setQuantity}
-            min={MIN_ORDER_QUANTITY}
-            max={MAX_ORDER_QUANTITY}
+            min={policy.MIN_ORDER_QUANTITY}
+            max={policy.MAX_ORDER_QUANTITY}
             size="S"
           />
         </Container>

--- a/client/src/components/Cart/CartMenuList/CartMenuItem/index.tsx
+++ b/client/src/components/Cart/CartMenuList/CartMenuItem/index.tsx
@@ -8,7 +8,7 @@ import { formatMoneyString } from 'utils';
 import QuantityController from 'components/QuantityController';
 import { useCartDispatchContext } from 'store/cart/cartContext';
 import Container from 'components/common/Container';
-import { policy } from 'policy';
+import policy from 'policy';
 
 export default function CartMenuItem({ cartItem }: { cartItem: ICartItem }) {
   const { id, name, imgUrl, totalPricePerEach, quantity } = cartItem;

--- a/client/src/components/Cart/CartUtils/index.tsx
+++ b/client/src/components/Cart/CartUtils/index.tsx
@@ -3,17 +3,38 @@ import styled, { css } from 'styled-components';
 import { colors } from 'style/constants';
 import Container from 'components/common/Container';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import { useCartDispatchContext } from 'store/cart/cartContext';
+import { usePageDispatchContext } from 'store/page/pageContext';
 
 export default function CartUtils() {
+  const dispatchPage = usePageDispatchContext();
+  const dispatchCart = useCartDispatchContext();
+  const cleanCart = () => {
+    dispatchCart({ type: 'DELETE_ALL' });
+  };
+  const moveToEntrancePage = () => {
+    cleanCart();
+    dispatchPage('ENTRANCE');
+  };
+
   return (
     <Container flexInfo={{ direction: 'column' }} gap={0.125} width="100%">
       <Container flexInfo={{ align: 'center' }} gap={0.125} width="100%">
-        <CustomButton width="25%" backgroundColor={colors.tertiary}>
+        <CustomButton
+          width="25%"
+          backgroundColor={colors.tertiary}
+          onClick={cleanCart}
+        >
           <DeleteOutlinedIcon />
         </CustomButton>
         <CustomButton backgroundColor={colors.primary}>주문하기</CustomButton>
       </Container>
-      <CustomButton backgroundColor={colors.darkGrey}>처음으로</CustomButton>
+      <CustomButton
+        backgroundColor={colors.darkGrey}
+        onClick={moveToEntrancePage}
+      >
+        처음으로
+      </CustomButton>
     </Container>
   );
 }

--- a/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
+++ b/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
 import QuantityController from 'components/QuantityController';
 import CustomButton from 'components/common/CustomButton';
 import { useCartDispatchContext } from 'store/cart/cartContext';
-import { MIN_ORDER_QUANTITY, MAX_ORDER_QUANTITY } from 'constants';
+import { policy } from 'policy';
 import ChoiceGroup from './ChoiceGroup';
 
 interface IMenuChoiceModal extends IMenu {
@@ -119,8 +119,8 @@ export default function MenuChoiceModal({
             <QuantityController
               quantity={quantity}
               setQuantity={setQuantity}
-              min={MIN_ORDER_QUANTITY}
-              max={MAX_ORDER_QUANTITY}
+              min={policy.MIN_ORDER_QUANTITY}
+              max={policy.MAX_ORDER_QUANTITY}
               size="L"
             />
           </Container>

--- a/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
+++ b/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
 import QuantityController from 'components/QuantityController';
 import CustomButton from 'components/common/CustomButton';
 import { useCartDispatchContext } from 'store/cart/cartContext';
-import { policy } from 'policy';
+import policy from 'policy';
 import ChoiceGroup from './ChoiceGroup';
 
 interface IMenuChoiceModal extends IMenu {

--- a/client/src/policy/index.ts
+++ b/client/src/policy/index.ts
@@ -1,6 +1,10 @@
-export const MIN_ORDER_QUANTITY = 1;
-export const MAX_ORDER_QUANTITY = 9;
-export const policy = {
+const MIN_ORDER_QUANTITY = 1;
+const MAX_ORDER_QUANTITY = 9;
+const RANKING_RANGE = 3;
+const policy = {
   MIN_ORDER_QUANTITY,
   MAX_ORDER_QUANTITY,
+  RANKING_RANGE,
 };
+
+export default policy;

--- a/client/src/policy/index.ts
+++ b/client/src/policy/index.ts
@@ -1,2 +1,6 @@
 export const MIN_ORDER_QUANTITY = 1;
 export const MAX_ORDER_QUANTITY = 9;
+export const policy = {
+  MIN_ORDER_QUANTITY,
+  MAX_ORDER_QUANTITY,
+};

--- a/client/src/store/cart/cartContext.tsx
+++ b/client/src/store/cart/cartContext.tsx
@@ -6,7 +6,8 @@ export type CartActionType =
   | { type: 'CHANGE_QUANTITY'; menuId: number; quantity: number }
   | { type: 'DELETE'; menuId: number }
   | { type: 'UPDATE'; itemData: ICartItem }
-  | { type: 'ADD'; itemData: ICartItem };
+  | { type: 'ADD'; itemData: ICartItem }
+  | { type: 'DELETE_ALL' };
 
 export const CartStateContext = createContext<CartStateType | null>(null);
 export const CartDispatchContext =

--- a/client/src/store/cart/cartReducer.ts
+++ b/client/src/store/cart/cartReducer.ts
@@ -31,6 +31,8 @@ export default function cartReducer(
     }
     case 'ADD':
       return [...state, action.itemData];
+    case 'DELETE_ALL':
+      return [];
     default:
       throw new Error('Invalid action');
   }

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -1,5 +1,5 @@
 export function formatMoneyString(money: number) {
-  return `${money.toLocaleString()}원`;
+  return `${money.toLocaleString()} 원`;
 }
 
 export function temp() {


### PR DESCRIPTION
## 설명

- 메인화면의 카트 기능을 구현했습니다.

## 작업한 내용

- 카트에서 수량 변경, 삭제
- 카트 전체 정보 (총 계, 총 품목 수) 표시
- 초기 화면으로 돌아가는 버튼
- 전체를 비우는 버튼 

## 특이사항

- 카트 품목을 클릭하여 수정 모달을 띄우는 로직은 dto 구조가 안맞아 대대적이 작업이 필요할 것 같습니다 ㅠㅠ
- 헷갈리는 작업이라 일단 우선순위가 높은 것부터 하고 나중에 추가하려구요

## 관련이슈

-  #20 
