### PR TITLE
feat: 원하는 컴포넌트에 portal를 잇도록 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,15 +4,23 @@ import { colors, shadows } from 'style/constants';
 import MainPage from 'pages/MainPage';
 import EntrancePage from 'pages/EntrancePage';
 import { usePageContext } from 'store/page/pageContext';
+import { useEffect, useRef } from 'react';
+import portalStore from 'store/portal';
 
 export default function App() {
   const currentPageType = usePageContext();
+  const displayRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!displayRef.current) return;
+    portalStore.setPortalRoot(displayRef.current);
+  }, []);
 
   return (
     <>
       <GlobalStyle />
       <KioskMachine>
-        <Display>
+        <Display ref={displayRef}>
           {currentPageType === 'ENTRANCE' && <EntrancePage />}
           {currentPageType === 'MAIN' && <MainPage />}
         </Display>

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -1,4 +1,5 @@
 import Container from 'components/common/Container';
+import portalStore from 'store/portal';
 import { colors } from 'style/constants';
 import styled, { css, CSSProp } from 'styled-components';
 
@@ -15,18 +16,21 @@ export default function CustomModal({
   contentStyle,
   backdropStyle,
 }: IModalProps) {
+  const Portal = portalStore.makePortal();
   return (
-    <Container
-      position="absolute"
-      top="0"
-      left="0"
-      width="100%"
-      height="100%"
-      flexInfo={{ justify: 'center', align: 'center' }}
-    >
-      <ModalBackdrop onClick={closeModal} backdropStyle={backdropStyle} />
-      <ModalContent contentStyle={contentStyle}>{children}</ModalContent>
-    </Container>
+    <Portal>
+      <Container
+        position="absolute"
+        top="0"
+        left="0"
+        width="100%"
+        height="100%"
+        flexInfo={{ justify: 'center', align: 'center' }}
+      >
+        <ModalBackdrop onClick={closeModal} backdropStyle={backdropStyle} />
+        <ModalContent contentStyle={contentStyle}>{children}</ModalContent>
+      </Container>
+    </Portal>
   );
 }
 
@@ -34,8 +38,8 @@ const ModalBackdrop = styled.div<{ backdropStyle?: CSSProp }>`
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  right: 0;
+  bottom: 0;
   z-index: 10;
   ${({ backdropStyle }) => backdropStyle}
 `;

--- a/client/src/store/portal/index.tsx
+++ b/client/src/store/portal/index.tsx
@@ -1,0 +1,17 @@
+import { createPortal } from 'react-dom';
+
+const portalStore = (() => {
+  let portalRoot: HTMLElement;
+  function setPortalRoot(newPortalRoot: HTMLElement) {
+    portalRoot = newPortalRoot;
+  }
+
+  function makePortal() {
+    return ({ children }: { children: React.ReactNode }) =>
+      createPortal(children, portalRoot);
+  }
+
+  return { makePortal, setPortalRoot };
+})();
+
+export default portalStore;


### PR DESCRIPTION
## 설명

-  기존의 모달은 모달을 띄우는 컴포넌트의 하위컴포넌트로 존재했기 때문에 위치 스타일링에 제약이 있었습니다.
-  일반적인 portal 예시에서는 index.html에 portal root용 div를 만들어 거기에 위치시키는데, 저는 원하는 컴포넌트를 포탈 루트로 사용하고 싶었습니다.

## 작업한 내용

- 전역적으로 관리되는 portal store 구현
- ref를 portal root로 설정하고 해당 root로 Portal을 만들어주는 makePortal 함수 구현
- 기존의 결제 모달창을 포탈을 이용하여 Display component 안에 띄움

## 특이사항

- 전역 portal store를 안전하게 관리할 방법은 없을까요..?

## 관련이슈

- #24 
