### PR TITLE
모달의 공통되는 요소를 컴포넌트로 분리

### DIFF
--- a/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
+++ b/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import CustomModal from 'components/Modal';
 import Container from 'components/common/Container';
 import { colors } from 'style/constants';
@@ -8,10 +8,10 @@ import MenuThumbnail from 'components/common/MenuThumbnail';
 import useAxios from 'hooks/useAxios';
 import { useEffect, useState } from 'react';
 import QuantityController from 'components/QuantityController';
-import CustomButton from 'components/common/CustomButton';
 import { useCartDispatchContext } from 'store/cart/cartContext';
 import policy from 'policy';
 import CommonModalHeader from 'components/Modal/CommonModalHeader';
+import CommonModalButtons from 'components/Modal/CommonModalButtons';
 import ChoiceGroup from './ChoiceGroup';
 
 interface IMenuChoiceModal extends IMenu {
@@ -133,18 +133,16 @@ export default function MenuChoiceModal({
               ))}
           </Container>
         </ContentBody>
-        <ChoiceModalButtons>
-          <CustomButton
-            style={CancleButtonStyle}
-            text="이전"
-            onClick={closeModal}
-          />
-          <CustomButton
-            style={ConfirmButtonStyle}
-            text="담기"
-            onClick={handleAddButtonClick}
-          />
-        </ChoiceModalButtons>
+        <CommonModalButtons
+          buttonInfos={[
+            { text: '이전', buttonColor: colors.darkGrey, onClick: closeModal },
+            {
+              text: '담기',
+              buttonColor: colors.primary,
+              onClick: handleAddButtonClick,
+            },
+          ]}
+        />
       </Container>
     </CustomModal>
   );
@@ -168,28 +166,4 @@ const TotalPrice = styled.span`
   font-size: 2.25rem;
   font-weight: 700;
   margin: 3rem 0 1.5rem 0;
-`;
-
-const ChoiceModalButtons = styled.div`
-  padding: 0rem 5rem 2rem 5rem;
-  background-color: ${colors.offWhite};
-  ${mixin.flexMixin({ align: 'center', justify: 'space-between' })}
-`;
-
-const CommonButtonStyle = css`
-  width: 13rem;
-  padding: 1.5rem 0;
-  color: ${colors.offWhite};
-  font-size: 1.5rem;
-  font-weight: 700;
-`;
-
-const CancleButtonStyle = css`
-  ${CommonButtonStyle};
-  background-color: ${colors.darkGrey};
-`;
-
-const ConfirmButtonStyle = css`
-  ${CommonButtonStyle}
-  background-color: ${colors.primary};
 `;

--- a/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
+++ b/client/src/components/MenuList/MenuItem/MenuChoiceModal/index.tsx
@@ -11,6 +11,7 @@ import QuantityController from 'components/QuantityController';
 import CustomButton from 'components/common/CustomButton';
 import { useCartDispatchContext } from 'store/cart/cartContext';
 import policy from 'policy';
+import CommonModalHeader from 'components/Modal/CommonModalHeader';
 import ChoiceGroup from './ChoiceGroup';
 
 interface IMenuChoiceModal extends IMenu {
@@ -101,16 +102,11 @@ export default function MenuChoiceModal({
   }, [isLoading]);
 
   return (
-    <CustomModal
-      contentStyle={css`
-        width: 75%;
-      `}
-      closeModal={closeModal}
-    >
+    <CustomModal closeModal={closeModal}>
       <Container width="100%">
-        <ContentTitle>
+        <CommonModalHeader>
           <h2>옵션 선택</h2>
-        </ContentTitle>
+        </CommonModalHeader>
         <ContentBody>
           <Container flexInfo={{ direction: 'column', align: 'center' }}>
             <MenuThumbnail size="L" imgUrl={imgUrl} />
@@ -153,16 +149,6 @@ export default function MenuChoiceModal({
     </CustomModal>
   );
 }
-
-const ContentTitle = styled.div`
-  width: 100%;
-  padding: 2rem;
-  background-color: ${colors.primary};
-  color: ${colors.offWhite};
-  font-size: 2rem;
-  font-weight: 700;
-  ${mixin.flexMixin({ justify: 'center', align: 'center' })}
-`;
 
 const ContentBody = styled.div`
   padding: 5rem 4rem;

--- a/client/src/components/MenuList/index.tsx
+++ b/client/src/components/MenuList/index.tsx
@@ -2,8 +2,6 @@ import useAxios from 'hooks/useAxios';
 import policy from 'policy';
 import { useEffect, useState } from 'react';
 import kioskStore from 'store/kiosk';
-import { colors } from 'style/constants';
-import mixin from 'style/mixin';
 import styled from 'styled-components';
 import { CategoryIdType, GetSalesStatApiResponseDto, MenuIdType } from 'types';
 import MenuItem from './MenuItem';

--- a/client/src/components/Modal/CommonModalButtons/index.tsx
+++ b/client/src/components/Modal/CommonModalButtons/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { colors } from 'style/constants';
 import mixin from 'style/mixin';
 import styled, { css } from 'styled-components';
@@ -23,6 +22,7 @@ export default function CommonModalButtons({
         const { text, buttonColor, onClick } = buttonInfo;
         return (
           <CustomButton
+            key={`${text}_button`}
             style={CommonButtonStyle}
             buttonColor={buttonColor}
             text={text}

--- a/client/src/components/Modal/CommonModalButtons/index.tsx
+++ b/client/src/components/Modal/CommonModalButtons/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { colors } from 'style/constants';
+import mixin from 'style/mixin';
+import styled, { css } from 'styled-components';
+import CustomButton from 'components/common/CustomButton';
+
+interface ICommonModalButton {
+  text: string;
+  buttonColor: string;
+  onClick: () => void;
+}
+
+interface ICommonModalButtonsProps {
+  buttonInfos: ICommonModalButton[];
+}
+
+export default function CommonModalButtons({
+  buttonInfos,
+}: ICommonModalButtonsProps) {
+  return (
+    <FooterWrapper>
+      {buttonInfos.map((buttonInfo) => {
+        const { text, buttonColor, onClick } = buttonInfo;
+        return (
+          <CustomButton
+            style={CommonButtonStyle}
+            buttonColor={buttonColor}
+            text={text}
+            onClick={onClick}
+          />
+        );
+      })}
+    </FooterWrapper>
+  );
+}
+
+const FooterWrapper = styled.div`
+  padding: 0rem 5rem 2rem 5rem;
+  background-color: ${colors.offWhite};
+  ${mixin.flexMixin({ align: 'center', justify: 'space-between' })}
+`;
+
+const CommonButtonStyle = css`
+  width: 13rem;
+  padding: 1.5rem 0;
+  color: ${colors.offWhite};
+  font-size: 1.5rem;
+  font-weight: 700;
+`;

--- a/client/src/components/Modal/CommonModalButtons/index.tsx
+++ b/client/src/components/Modal/CommonModalButtons/index.tsx
@@ -17,30 +17,30 @@ export default function CommonModalButtons({
   buttonInfos,
 }: ICommonModalButtonsProps) {
   return (
-    <FooterWrapper>
+    <ModalButtonsWrapper>
       {buttonInfos.map((buttonInfo) => {
         const { text, buttonColor, onClick } = buttonInfo;
         return (
           <CustomButton
             key={`${text}_button`}
-            style={CommonButtonStyle}
+            style={CommonModalButtonStyle}
             buttonColor={buttonColor}
             text={text}
             onClick={onClick}
           />
         );
       })}
-    </FooterWrapper>
+    </ModalButtonsWrapper>
   );
 }
 
-const FooterWrapper = styled.div`
+const ModalButtonsWrapper = styled.div`
   padding: 0rem 5rem 2rem 5rem;
   background-color: ${colors.offWhite};
   ${mixin.flexMixin({ align: 'center', justify: 'space-between' })}
 `;
 
-const CommonButtonStyle = css`
+const CommonModalButtonStyle = css`
   width: 13rem;
   padding: 1.5rem 0;
   color: ${colors.offWhite};

--- a/client/src/components/Modal/CommonModalHeader/index.tsx
+++ b/client/src/components/Modal/CommonModalHeader/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { colors } from 'style/constants';
+import mixin from 'style/mixin';
+import styled from 'styled-components';
+
+export default function CommonModalHeader({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <HeaderWrapper>{children}</HeaderWrapper>;
+}
+
+const HeaderWrapper = styled.div`
+  width: 100%;
+  padding: 2rem;
+  background-color: ${colors.primary};
+  color: ${colors.offWhite};
+  font-size: 2rem;
+  font-weight: 700;
+  ${mixin.flexMixin({ justify: 'center', align: 'center' })}
+`;

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -1,7 +1,7 @@
-import Container from 'components/common/Container';
+import styled, { CSSProp } from 'styled-components';
 import portalStore from 'store/portal';
 import { colors } from 'style/constants';
-import styled, { css, CSSProp } from 'styled-components';
+import Container from 'components/common/Container';
 
 interface IModalProps {
   children: React.ReactNode;
@@ -41,23 +41,13 @@ const ModalBackdrop = styled.div<{ backdropStyle?: CSSProp }>`
   right: 0;
   bottom: 0;
   z-index: 10;
+  background-color: rgba(0, 0, 0, 0.4);
   ${({ backdropStyle }) => backdropStyle}
 `;
 
 const ModalContent = styled.div<{ contentStyle?: CSSProp }>`
   z-index: 11;
+  width: 75%;
+  background-color: ${colors.offWhite};
   ${({ contentStyle }) => contentStyle}
 `;
-
-const defaultBackdropStyle = css`
-  background-color: rgba(0, 0, 0, 0.4);
-`;
-
-const defaultContentStyle = css`
-  background-color: ${colors.offWhite};
-`;
-
-CustomModal.defaultProps = {
-  contentStyle: defaultContentStyle,
-  backdropStyle: defaultBackdropStyle,
-};

--- a/client/src/components/common/CustomButton.tsx
+++ b/client/src/components/common/CustomButton.tsx
@@ -1,23 +1,26 @@
 import styled, { CSSProp } from 'styled-components';
 
 interface ICustomButtonProps {
-  style: CSSProp;
+  style?: CSSProp;
+  buttonColor?: string;
   text: string;
   onClick: () => void;
 }
 
 export default function CustomButton({
   style,
+  buttonColor,
   text,
   onClick,
 }: ICustomButtonProps) {
   return (
-    <MyButton onClick={onClick} buttonStyle={style}>
+    <MyButton onClick={onClick} buttonStyle={style} buttonColor={buttonColor}>
       {text}
     </MyButton>
   );
 }
 
-const MyButton = styled.button<{ buttonStyle: CSSProp }>`
+const MyButton = styled.button<{ buttonColor?: string; buttonStyle?: CSSProp }>`
+  background-color: ${({ buttonColor }) => buttonColor};
   ${({ buttonStyle }) => buttonStyle}
 `;


### PR DESCRIPTION
## 설명

- 모달마다 비슷하게 반복되는 헤더와 아래 버튼들을 컴포넌트화 했습니다.
- 일부러 많은 선택지를 열어두기보다 최소한으로만 추상화했습니다. 이후 필요시 파라미터 종류를 추가할 것 같습니다.

## 작업한 내용

- CommonModalHeader 구현 (색상은 고정)
- CommonModalButtons 구현 (버튼 정보를 받아서 일정한 레이아웃에 맞게 그려주는 역할)

## 관련이슈

- #27
