### PR TITLE
영수증 모달 구현

### DIFF
--- a/client/src/components/Order/PayMoneyStage/index.tsx
+++ b/client/src/components/Order/PayMoneyStage/index.tsx
@@ -8,16 +8,19 @@ import { useCartStateContext } from 'store/cart/cartContext';
 import kioskStore from 'store/kiosk';
 import { colors } from 'style/constants';
 import styled from 'styled-components';
+import { PostOrderApiResponseDto } from 'types';
 import { IOrderModalProps, TPaymentMethod } from '../types';
 
 interface IPayMoneyStageProps extends IOrderModalProps {
   paymentMethodName: TPaymentMethod;
+  setOrderResult: React.Dispatch<PostOrderApiResponseDto | null>;
 }
 
 export default function PayMoneyStage({
   closeModal,
   moveStage,
   paymentMethodName,
+  setOrderResult,
 }: IPayMoneyStageProps) {
   const cartState = useCartStateContext();
 
@@ -47,10 +50,12 @@ export default function PayMoneyStage({
     data: paymentResult,
     error,
     isLoading,
-  } = useAxios<{ status: 'ok' | 'fail' }>('/order', 'post', orderRequestBody);
+  } = useAxios<PostOrderApiResponseDto>('/order', 'post', orderRequestBody);
 
   useEffect(() => {
-    if (paymentResult?.status === 'ok') moveStage('SHOW_BILL');
+    if (paymentResult?.status !== 'ok') return;
+    setOrderResult(paymentResult);
+    moveStage('SHOW_BILL');
   }, [isLoading]);
 
   return (

--- a/client/src/components/Order/ShowBillStage/index.tsx
+++ b/client/src/components/Order/ShowBillStage/index.tsx
@@ -1,0 +1,53 @@
+import { colors } from 'style/constants';
+import mixin from 'style/mixin';
+import styled from 'styled-components';
+
+interface IShowBillStageProps {
+  closeModal: () => void;
+}
+
+export default function ShowBillStage({ closeModal }: IShowBillStageProps) {
+  return (
+    <>
+      <OrderNumber>주문번호 22번</OrderNumber>
+      <SoldMenuWrapper>
+        <SoldMenu>
+          <OrderMenuInfo>
+            <MenuName>라떼</MenuName>
+            <MenuChoices>아이스 / 히히</MenuChoices>
+          </OrderMenuInfo>
+          <MenuPrice>1,000원</MenuPrice>
+        </SoldMenu>
+      </SoldMenuWrapper>
+    </>
+  );
+}
+
+const OrderNumber = styled.span`
+  font-size: 2rem;
+  font-weight: 600;
+`;
+
+const SoldMenuWrapper = styled.ul``;
+const SoldMenu = styled.li``;
+const OrderMenuInfo = styled.div`
+  margin-left: 2rem;
+  flex-grow: 1;
+  ${mixin.flexMixin({ direction: 'column', justify: 'space-around' })}
+`;
+
+const MenuName = styled.span`
+  margin-top: 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 500;
+`;
+
+const MenuChoices = styled.span`
+  font-size: 1.25rem;
+  color: ${colors.placeholder};
+`;
+
+const MenuPrice = styled.span`
+  font-size: 1.5rem;
+  font-weight: 600;
+`;

--- a/client/src/components/Order/ShowBillStage/index.tsx
+++ b/client/src/components/Order/ShowBillStage/index.tsx
@@ -58,7 +58,9 @@ export default function ShowBillStage({
           );
         })}
       </SoldMenuWrapper>
-      <AlertMessage>{displayTime}</AlertMessage>
+      <AlertMessage>
+        이 창은 <span>{displayTime}</span> 후에 자동으로 닫힙니다.
+      </AlertMessage>
     </>
   );
 }
@@ -114,5 +116,10 @@ const MenuPrice = styled.span`
 `;
 
 const AlertMessage = styled.span`
-  ${colors.error}
+  margin: 0 auto;
+  font-size: 1.25rem;
+
+  & span {
+    color: ${colors.error};
+  }
 `;

--- a/client/src/components/Order/ShowBillStage/index.tsx
+++ b/client/src/components/Order/ShowBillStage/index.tsx
@@ -1,39 +1,95 @@
+import policy from 'policy';
+import { useEffect, useState } from 'react';
 import { colors } from 'style/constants';
 import mixin from 'style/mixin';
 import styled from 'styled-components';
+import { PostOrderApiResponseDto } from 'types';
+import { formatMoneyString } from 'utils';
 
 interface IShowBillStageProps {
   closeModal: () => void;
+  orderResult: PostOrderApiResponseDto | null;
 }
 
-export default function ShowBillStage({ closeModal }: IShowBillStageProps) {
+export default function ShowBillStage({
+  closeModal,
+  orderResult,
+}: IShowBillStageProps) {
+  const [displayTime, setDisplaytime] = useState(policy.BILL_DISPLAYING_TIME);
+
+  if (!orderResult) return <div>todo: 에러페이지</div>;
+
+  const handleDisplayTime = (leftTime: number, timerId: NodeJS.Timer) => {
+    if (leftTime > 0) return;
+    clearInterval(timerId);
+    closeModal();
+  };
+
+  useEffect(() => {
+    const timerId = setInterval(() => {
+      setDisplaytime((prev) => {
+        const leftTime = prev - 1;
+        handleDisplayTime(leftTime, timerId);
+        return leftTime;
+      });
+    }, 1000);
+  }, []);
+
+  const { todayOrderNum, soldMenus } = orderResult.data;
   return (
     <>
-      <OrderNumber>주문번호 22번</OrderNumber>
+      <OrderNumber>주문번호 {todayOrderNum}번</OrderNumber>
       <SoldMenuWrapper>
-        <SoldMenu>
-          <OrderMenuInfo>
-            <MenuName>라떼</MenuName>
-            <MenuChoices>아이스 / 히히</MenuChoices>
-          </OrderMenuInfo>
-          <MenuPrice>1,000원</MenuPrice>
-        </SoldMenu>
+        {soldMenus.map((soldMenu) => {
+          const { menuName, quantity, sales, choiceSummary } = soldMenu;
+          return (
+            <SoldMenu key={`${menuName}_${choiceSummary}`}>
+              <MenuInfoWrapper>
+                <MenuName>{menuName}</MenuName>
+                <MenuChoices>
+                  {JSON.parse(choiceSummary).join(' / ')}
+                </MenuChoices>
+              </MenuInfoWrapper>
+              <SalesWrapper>
+                <SoldQuantity>{quantity}개</SoldQuantity>
+                <MenuPrice>{formatMoneyString(sales)}</MenuPrice>
+              </SalesWrapper>
+            </SoldMenu>
+          );
+        })}
       </SoldMenuWrapper>
+      <AlertMessage>{displayTime}</AlertMessage>
     </>
   );
 }
 
 const OrderNumber = styled.span`
-  font-size: 2rem;
-  font-weight: 600;
+  margin: 0 auto;
+  font-size: 2.5rem;
+  font-weight: 700;
 `;
 
-const SoldMenuWrapper = styled.ul``;
-const SoldMenu = styled.li``;
-const OrderMenuInfo = styled.div`
-  margin-left: 2rem;
+const SoldMenuWrapper = styled.ul`
+  width: 100%;
+  margin-top: 3rem;
   flex-grow: 1;
-  ${mixin.flexMixin({ direction: 'column', justify: 'space-around' })}
+`;
+
+const SoldMenu = styled.li`
+  width: 100%;
+  padding: 1rem 0;
+  ${mixin.flexMixin({ justify: 'space-between', align: 'center' })}
+  border-bottom: 1px solid ${colors.darkGrey};
+`;
+
+const MenuInfoWrapper = styled.div`
+  gap: 1rem;
+  ${mixin.flexMixin({ direction: 'column' })}
+`;
+
+const SalesWrapper = styled.div`
+  gap: 1rem;
+  ${mixin.flexMixin({ direction: 'column', align: 'flex-end' })}
 `;
 
 const MenuName = styled.span`
@@ -47,7 +103,16 @@ const MenuChoices = styled.span`
   color: ${colors.placeholder};
 `;
 
+const SoldQuantity = styled.span`
+  font-size: 1.5rem;
+  font-weight: 400;
+`;
+
 const MenuPrice = styled.span`
   font-size: 1.5rem;
   font-weight: 600;
+`;
+
+const AlertMessage = styled.span`
+  ${colors.error}
 `;

--- a/client/src/components/Order/index.tsx
+++ b/client/src/components/Order/index.tsx
@@ -3,6 +3,7 @@ import CommonModalHeader from 'components/Modal/CommonModalHeader';
 import { useState } from 'react';
 import mixin from 'style/mixin';
 import styled from 'styled-components';
+import { PostOrderApiResponseDto } from 'types';
 import CheckOrderStage from './CheckOrderStage';
 import ChoosePaymentMethodStage from './ChoosePaymentMethodStage';
 import PayMoneyStage from './PayMoneyStage';
@@ -15,7 +16,8 @@ export interface IOrderStageModalProps {
 
 export default function OrderModal({ closeModal }: IOrderStageModalProps) {
   const [orderStage, setOrderState] = useState<TOrderStage>('CHECK_ORDER');
-
+  const [orderResult, setOrderResult] =
+    useState<PostOrderApiResponseDto | null>(null);
   const moveStage = (stageName: TOrderStage) => {
     setOrderState(stageName);
   };
@@ -43,6 +45,7 @@ export default function OrderModal({ closeModal }: IOrderStageModalProps) {
           closeModal={closeModal}
           moveStage={moveStage}
           paymentMethodName="CARD"
+          setOrderResult={setOrderResult}
         />
       ),
     },
@@ -53,12 +56,15 @@ export default function OrderModal({ closeModal }: IOrderStageModalProps) {
           closeModal={closeModal}
           moveStage={moveStage}
           paymentMethodName="CASH"
+          setOrderResult={setOrderResult}
         />
       ),
     },
     SHOW_BILL: {
       title: '주문 결과를 확인해주세요.',
-      contents: <ShowBillStage closeModal={closeModal} />,
+      contents: (
+        <ShowBillStage closeModal={closeModal} orderResult={orderResult} />
+      ),
     },
   };
 

--- a/client/src/components/Order/index.tsx
+++ b/client/src/components/Order/index.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import CheckOrderStage from './CheckOrderStage';
 import ChoosePaymentMethodStage from './ChoosePaymentMethodStage';
 import PayMoneyStage from './PayMoneyStage';
+import ShowBillStage from './ShowBillStage';
 import { TOrderStage } from './types';
 
 export interface IOrderStageModalProps {
@@ -57,9 +58,7 @@ export default function OrderModal({ closeModal }: IOrderStageModalProps) {
     },
     SHOW_BILL: {
       title: '주문 결과를 확인해주세요.',
-      contents: (
-        <CheckOrderStage closeModal={closeModal} moveStage={moveStage} />
-      ),
+      contents: <ShowBillStage closeModal={closeModal} />,
     },
   };
 

--- a/client/src/policy/index.ts
+++ b/client/src/policy/index.ts
@@ -8,6 +8,7 @@ const PAYMENT_METHOD_NAMES = {
   CARD: '카드',
   CASH: '현금',
 };
+const BILL_DISPLAYING_TIME = 7;
 const policy = {
   MIN_ORDER_QUANTITY,
   MAX_ORDER_QUANTITY,
@@ -16,6 +17,7 @@ const policy = {
   SECONDARY_RANK_RANGE,
   TERTIARY_RANK_RANKGE,
   PAYMENT_METHOD_NAMES,
+  BILL_DISPLAYING_TIME,
 };
 
 export default policy;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 export type CategoryIdType = number;
 export interface ICategory {
   id: CategoryIdType;
@@ -52,8 +50,22 @@ export interface IMenusGroupByCategory extends ICategory {
   menus: IMenu[];
 }
 
+type TServerSavedSoldMenu = {
+  menuName: string;
+  quantity: number;
+  sales: number;
+  choiceSummary: string;
+};
+
 export type GetMenuCategoriesApiResponseDto = ICategory[];
 export type GetMenusApiResponseDto = IMenusGroupByCategory[];
 export type GetPaymentMethodsApiResponseDto = IPaymentMethod[];
 export type GetChoicesApiResponseDto = IChoiceGroup[];
 export type GetSalesStatApiResponseDto = IMenuSales[];
+export type PostOrderApiResponseDto = {
+  status: 'ok' | 'fail';
+  data: {
+    todayOrderNum: number;
+    soldMenus: TServerSavedSoldMenu[];
+  };
+};

--- a/server/src/order/order.controller.ts
+++ b/server/src/order/order.controller.ts
@@ -19,7 +19,7 @@ export class OrderController {
     const { todayOrderNum, savedSoldMenus } = await this.orderService.create(
       createOrderDto,
     );
-    const soldmenus = savedSoldMenus.map((soldMenu) => {
+    const soldMenus = savedSoldMenus.map((soldMenu) => {
       const { menu, quantity, sales, choiceSummary } = soldMenu;
       return {
         menuName: menu.name,
@@ -32,7 +32,7 @@ export class OrderController {
       status: 'ok',
       data: {
         todayOrderNum,
-        soldmenus,
+        soldMenus,
       },
     });
   }

--- a/server/src/order/order.controller.ts
+++ b/server/src/order/order.controller.ts
@@ -16,7 +16,24 @@ export class OrderController {
     );
     if (!isValidPayment)
       return res.status(HttpStatus.I_AM_A_TEAPOT).json({ status: 'failed' });
-    await this.orderService.create(createOrderDto);
-    return res.status(HttpStatus.CREATED).json({ status: 'ok' });
+    const { todayOrderNum, savedSoldMenus } = await this.orderService.create(
+      createOrderDto,
+    );
+    const soldmenus = savedSoldMenus.map((soldMenu) => {
+      const { menu, quantity, sales, choiceSummary } = soldMenu;
+      return {
+        menuName: menu.name,
+        quantity,
+        sales,
+        choiceSummary,
+      };
+    });
+    return res.status(HttpStatus.CREATED).json({
+      status: 'ok',
+      data: {
+        todayOrderNum,
+        soldmenus,
+      },
+    });
   }
 }

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -1,7 +1,23 @@
+import { Between, FindOperator } from 'typeorm';
+
 export function getRandom(min: number, max: number): number {
   return Math.random() * (max - min) + min;
 }
 
 export function getRandomResult(successRatio: number): boolean {
   return Math.random() < successRatio;
+}
+
+function getMidNight(year: number, month: number, date: number) {
+  const timeZoneOffset = -9;
+  return new Date(year, month, date, timeZoneOffset, 0, 0, 0);
+}
+
+export function getYesterday(date: Date): FindOperator<Date> {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const dateNum = date.getDate();
+  const todayMidNight = getMidNight(year, month, dateNum);
+  const yesterDayMidNight = getMidNight(year, month, dateNum - 1);
+  return Between(yesterDayMidNight, todayMidNight);
 }


### PR DESCRIPTION
## 설명

- 영수증에 필요한 데이터는 클라이언트에도 있지만, 서버와 확실히 동기화하기 위해 서버에 있는 데이터를 다시 응답받는 것이 좋겠다고 생각했습니다. 
- 서버에서 계산한 각 상품의 금액으로 영수증을 구성합니다.

## 작업한 내용


https://user-images.githubusercontent.com/95538993/183980386-a20f8366-b1a7-4ede-9a12-56d72239e7f2.mp4



- 서버에서 그날 몇 번째 주문인지 계산
- 서버로부터 받아온 데이터로 영수증 렌더
- 일정 시간 이후에 꺼지도록 구현

## 특이사항

- react strict 모드는 두번씩 실행시키는 것으로 알고 있는데, 그래서 그런지 2초씩 줄어드네요.. 해결해야되는 문제인건지 production에서는 관계없는 일인지 확인해봐야겠습니다.

## 관련이슈

- #37 #36 
